### PR TITLE
Replaces 'rm -rf' with rimraf to support non-Unix builds

### DIFF
--- a/packages/burnside-dom/changelog.md
+++ b/packages/burnside-dom/changelog.md
@@ -3,6 +3,10 @@ Details on how to contribute to this changelog see the website
 [Keep a change Log.](http://keepachangelog.com/) All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.3]
+### Changed
+- Replaces Unix `rm -rf` with the rmraf module for Windows development
+
 ## [0.3.2]
 ### Changed
 Updated description

--- a/packages/burnside-dom/package.json
+++ b/packages/burnside-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnside-dom",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "DOM Extensions for Burnside's Clientside Testing Library",
   "repository": {
     "type": "bitbucket",
@@ -13,7 +13,7 @@
   "license": "UNLICENSED",
   "main": "lib/index.js",
   "scripts": {
-    "clean": "rm -rf lib",
+    "clean": "rimraf lib",
     "babel": "babel src --out-dir lib --source-maps inline",
     "prepublish": "npm run clean && npm run babel",
     "check-coverage": "istanbul check-coverage reports/coverage/coverage-final.json",
@@ -60,6 +60,7 @@
     "mocha": "^3.2.0",
     "opener": "^1.4.1",
     "proxyquire": "^1.7.10",
+    "rimraf": "^2.6.2",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
     "webpack": "^1.13.1"

--- a/packages/burnside-localproxy/changelog.md
+++ b/packages/burnside-localproxy/changelog.md
@@ -3,6 +3,10 @@ Details on how to contribute to this changelog see the website
 [Keep a change Log.](http://keepachangelog.com/) All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.3]
+### Changed
+- Replaces Unix `rm -rf` with the rmraf module for Windows development
+
 ## [0.3.2]
 ### Changed
 - Replaces Nike images with a kitten

--- a/packages/burnside-localproxy/package.json
+++ b/packages/burnside-localproxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnside-localproxy",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Node HTTP Proxy that injects the Burnside Client",
   "repository": {
     "type": "github",
@@ -11,7 +11,7 @@
   },
   "main": "lib/index.js",
   "scripts": {
-    "clean": "rm -rf lib",
+    "clean": "rimraf lib",
     "babel": "babel src --out-dir lib --source-maps inline",
     "prepublish": "npm run clean && npm run babel",
     "karma": "karma start",
@@ -62,6 +62,7 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^3.2.0",
     "opener": "^1.4.1",
+    "rimraf": "^2.6.2",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
     "webpack": "^1.13.1"

--- a/packages/burnside/changelog.md
+++ b/packages/burnside/changelog.md
@@ -3,6 +3,10 @@ Details on how to contribute to this changelog see the website
 [Keep a change Log.](http://keepachangelog.com/) All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.2]
+### Changed
+- Replaces Unix `rm -rf` with the rmraf module for Windows development
+
 ## [0.3.1]
 ### Changed
 - Updates the package.json description

--- a/packages/burnside/package.json
+++ b/packages/burnside/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnside",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Fast and Reliable E2E Web Testing. Core Clientside Library.",
   "repository": {
     "type": "github",
@@ -14,7 +14,7 @@
   "main": "lib/index.js",
   "engines": {},
   "scripts": {
-    "clean": "rm -rf lib",
+    "clean": "rimraf lib",
     "babel": "babel src --out-dir lib --source-maps inline",
     "prepublish": "npm run clean && npm run babel",
     "check-coverage": "istanbul check-coverage reports/coverage/coverage-final.json",
@@ -65,6 +65,7 @@
     "mocha": "^3.2.0",
     "opener": "^1.4.1",
     "proxyquire": "^1.7.10",
+    "rimraf": "^2.6.2",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
     "webpack": "^1.13.1"


### PR DESCRIPTION
Several of the packages are building by first deleting their lib directory. This is failing on windows.