### PR TITLE
Fix the tutorial script for Windows users

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 Details on how to contribute to this changelog see the website
 [Keep a change Log.](http://keepachangelog.com/) All notable changes to this project will be documented in this file.
 
+## [0.3.2]
+# Changed
+- Updates the tutorial script for windows users.
+- Flags burnside-root as private to prevent publishing the empty monorepo root
+
+## [0.3.1]
+# Changed
+- OSS
+
 ## [0.3.0]
 # Changed
 - Removes burnside-analytics

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "burnside-root",
-  "version": "0.3.1",
+  "version": "0.3.2",
+  "private": true,
   "repository": {
     "type": "github",
     "url": "https://github.com/Nike-Inc/burnside.git"
   },
   "scripts": {
-    "tutorial": "cd packages/burnside-cli && npm run tutorial",
+    "tutorial": "cd packages && cd burnside-cli && npm install && npm run tutorial",
     "custom-install": "lerna bootstrap",
     "test": "lerna run test --concurrency 1",
     "test:dev": "lerna run test",

--- a/packages/burnside-cli/changelog.md
+++ b/packages/burnside-cli/changelog.md
@@ -3,6 +3,10 @@ Details on how to contribute to this changelog see the website
 [Keep a change Log.](http://keepachangelog.com/) All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.4]
+### Added
+Fixes broken link pointing to deleted cli sample project in the tutorial
+
 ## [0.3.3]
 ### Added
 Support for custom karma configurations and sample usage.

--- a/packages/burnside-cli/package.json
+++ b/packages/burnside-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burnside-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "End To End Web Testing with no dependencies built on pure Node. CLI",
   "repository": {
     "type": "github",

--- a/packages/burnside-cli/resources/tutorial.html
+++ b/packages/burnside-cli/resources/tutorial.html
@@ -67,7 +67,7 @@ it('should wait and then retrieve the HTML of the selector', () => {
           <p class="fragment">Then, in your test file</p>
           <p class="fragment"><code style="background:black;" class="">const {Burnside} = window;</code></p>
           <p class="fragment">and you're ready to test!</p>
-          <p class="fragment">For more information visit our <a href="https://bitbucket.nike.com/projects/WEBCD/repos/burnside/browse/packages/burnside-cli-sample">CLI Sample Configuration Package</a></p>
+          <p class="fragment">For more information visit our <a href="https://bitbucket.nike.com/projects/WEBCD/repos/burnside/browse/packages/burnside-sample">Sample Configuration Package</a></p>
           </section>
           <section>
             <h2 id="titleHeader">Configuration and Use</h2>

--- a/readme.md
+++ b/readme.md
@@ -113,9 +113,7 @@ The Burnside tutorial is a set of exercises designed to walk you through how to 
 ```
 git clone https://github.com/Nike-Inc/burnside.git
 
-cd burnside
-npm install && npm run custom-install
-npm run tutorial
+cd burnside && npm run tutorial
 ```
 Now you're all configured! If you'd like to contribute to the Tutorial, please read our [Tutorial Developers Guide](https://github.com/Nike-Inc/burnside/blob/master/docs/tutorial.md)
 


### PR DESCRIPTION
Windows users cannot seem to bootstrap Lerna cleanly. This PR attempts to
fix that by updating the tutorial script to only install the CLI's
dependencies from NPM rather than a full Lerna Bootstrap. It also fixes a
broken link I found in the tutorial pointing to a now deleted CLI sample
project.